### PR TITLE
fix(ci): replace invalid sign-artifacts input in PyPI publish workflows

### DIFF
--- a/.github/workflows/publish_pypi_prod.yml
+++ b/.github/workflows/publish_pypi_prod.yml
@@ -34,4 +34,4 @@ jobs:
         # if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
-          sign-artifacts: true
+          attestations: true

--- a/.github/workflows/publish_pypi_test.yml
+++ b/.github/workflows/publish_pypi_test.yml
@@ -31,5 +31,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/
-          sign-artifacts: true
           skip-existing: true


### PR DESCRIPTION
## Summary

- Remove invalid `sign-artifacts: true` input from `pypa/gh-action-pypi-publish` in both PyPI publish workflows
- Replace with explicit `attestations: true` in the prod workflow (default but kept for clarity)
- Fixes the "Unexpected input(s) 'sign-artifacts'" warnings in [publish-to-pypi](https://github.com/reqstool/reqstool-python-decorators/actions/runs/22808810260)

## Test plan

- [ ] Verify test PyPI publish workflow runs without the `sign-artifacts` warning
- [ ] Verify prod PyPI publish workflow runs without the `sign-artifacts` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)