### PR TITLE
ci: add build-docs workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,15 @@
+name: Build Docs
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "docs/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+
+jobs:
+  build:
+    uses: reqstool/.github/.github/workflows/build-docs.yml@main


### PR DESCRIPTION
## Summary
- Add caller workflow for centralized Antora docs build validation
- Runs on PRs and pushes to main when `docs/**` files change
- Calls reusable workflow from `reqstool/.github`

## Test plan
- [ ] Verify Build Docs workflow passes after merge