### PR TITLE
build(ci): pin the tools these workflows install at runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,8 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install dependencies
-        run: pip install hatch
+        # renovate: datasource=pypi depName=hatch
+        run: pip install hatch==1.18.0
       - name: Run tests
         run: hatch run dev:pytest --junitxml=build/junit.xml --cov=reqstool_python_decorators --cov-report=xml:build/coverage.xml
       - name: Build project

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,8 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install pip package(s)
-        run: pip install hatch
+        # renovate: datasource=pypi depName=hatch
+        run: pip install hatch==1.18.0
       - name: Run black formatter check
         run: hatch run dev:black --check --verbose src tests
       - name: Run flake8 linter


### PR DESCRIPTION
ⓘ Follow-up to the pinning sweep. The first survey only looked at package manifests and **missed this whole class**: tools installed at runtime inside a workflow.

## What & Why

`pip install <name>` and `npm install -g <name>` resolve to whatever is newest at the moment the job runs. That is a dependency like any other — it executes in CI, and in some repos it feeds a publish — so an unpinned one is exactly the risk pinning exists to remove.

Each pin carries a `# renovate:` comment, so it is **tracked rather than merely frozen** — the distinction that mattered for the Nisse pin Renovate silently skipped. The custom manager in `reqstool/.github` picks these up and will raise upgrades as ordinary PRs.

Pinned to the current latest of each.

## Author checklist

- [x] `actionlint` clean — the pre-existing shellcheck findings in these files are unchanged (verified before/after)
- [x] `# renovate:` annotations verified to be discovered by the manager regexes
- [x] Conventional Commit title, DCO sign-off