### PR TITLE
fix(ci): add explicit permissions to lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the open CodeQL alert (`actions/missing-workflow-permissions`) on this file: no `permissions:` block anywhere, so it ran with the repo's default token permissions rather than what it actually needs. It only checks out and reads the repo — `contents: read` covers it.

## Checklist
- [x] I have reviewed and followed the contributing guidelines.
- [x] I have run a local build and made sure all tests pass.
- [x] I have signed off the DCO (`git commit -s`).
- [x] I have read the Code of Conduct and agree to abide by it.

## Test plan
YAML validated locally. CodeQL re-scan on this PR should close the alert.