### PR TITLE
fix(ci): inline the PyPI publish step instead of a composite action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,10 +109,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8.0.1
+      - uses: reqstool/.github/.github/actions/download-dists@main
         with:
-          name: dist-tagged
-          path: dist
+          artifact: dist-tagged
+      # Inline, not inside download-dists: nesting this Docker action in a
+      # composite action makes GitHub resolve its image against the wrapper's
+      # repo. See reqstool/.github#95.
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,9 +109,13 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: reqstool/.github/.github/actions/publish-to-pypi@b10b898cd5a1d552a578dbe4f170f84fb8f98b6c # main 2026-08-23
+      - uses: actions/download-artifact@v8.0.1
         with:
-          artifact: dist-tagged
+          name: dist-tagged
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          attestations: true
 
   # Last, deliberately. Everything above can fail, and until this runs nothing
   # resolving "the latest release" can see what was built -- the release is still


### PR DESCRIPTION
## Description

Companion to [reqstool/.github#94](https://github.com/reqstool/.github/pull/94) — see
[reqstool/.github#95](https://github.com/reqstool/.github/issues/95), **including the
corrections in the second comment**.

Today's real release run failed at `publish-to-pypi`:

```
docker run ... ghcr.io/reqstool/.github:b10b898cd5a1d552a578dbe4f170f84fb8f98b6c
docker: invalid reference format
```

`pypa/gh-action-pypi-publish` is a Docker container action, and nesting one inside a
composite action makes GitHub resolve its image against the wrapping action's repository
rather than its own. Its own maintainer
[describes the same breakage](https://github.com/pypi/warehouse/issues/11096#issuecomment-2871981512).

The composite action itself was fine — it creates no new workflow context, so the job keeps
this repo's own OIDC identity, which is why it works where a cross-repo reusable workflow
does not. So only the publish step comes out.

## What changes

```yaml
      - uses: reqstool/.github/.github/actions/download-dists@main
        with:
          artifact: dist-tagged
      # Inline, not inside download-dists: nesting this Docker action in a
      # composite action makes GitHub resolve its image against the wrapper's repo.
      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
        with:
          attestations: true
```

`download-dists` is `actions/publish-to-pypi` renamed — it no longer publishes.

**Needs reqstool/.github#94 merged first**, and the `@main` reference gets pinned to a commit
SHA before this merges (no SHA exists to pin to until #94 lands).

## Checklist

- [x] I have reviewed and followed the [contributing guidelines](../CONTRIBUTING.md).
- [x] I have run a local build and made sure all tests pass.
- [x] I have signed off the [Developer Certificate of Origin](../dco.txt) (`git commit -s`).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.

## Test plan

YAML validated locally. The real test is a dispatch reaching a successful `publish-to-pypi` —
no local check catches this class of bug.
