### PR TITLE
fix(ci): pin the download-dists action reference to a commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: reqstool/.github/.github/actions/download-dists@main
+      - uses: reqstool/.github/.github/actions/download-dists@ef815eae0bca7160cdc714126cac73f76d638b39 # main 2026-08-23
         with:
           artifact: dist-tagged
       # Inline, not inside download-dists: nesting this Docker action in a


### PR DESCRIPTION
Closes the CodeQL `actions/unpinned-tag` alert opened when [#94](https://github.com/reqstool/.github/pull/94)'s companion merged.

`@main` is a mutable ref — a compromised or force-pushed `reqstool/.github` main would execute through this reference with no review. Pinned to `ef815ea`, the commit that added `download-dists`, matching the `@<sha> # main YYYY-MM-DD` convention already used for every other `reqstool/.github` reference in this repo.

It went in as `@main` only because no commit SHA existed to pin to until #94 merged.

## Checklist
- [x] I have reviewed and followed the contributing guidelines.
- [x] I have run a local build and made sure all tests pass.
- [x] I have signed off the DCO (`git commit -s`).
- [x] I have read the Code of Conduct and agree to abide by it.

## Test plan
YAML validated locally; CodeQL re-scan on this PR should close the alert. The action's content is unchanged — same tree, pinned rather than floating.