### PR TITLE
chore(github-actions): pin reqstool/.github references to 1.0.0

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   build:
-    uses: reqstool/.github/.github/workflows/common-build-docs.yml@main
+    uses: reqstool/.github/.github/workflows/common-build-docs.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         # cleaning build/, move the pytest output dir outside of it.
         run: hatch run dev:python scripts/generate_annotations.py
       - name: Install reqstool
-        uses: reqstool/.github/.github/actions/install-reqstool@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+        uses: reqstool/.github/.github/actions/install-reqstool@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
         with:
           reqstool-source: ${{ matrix.reqstool-source }}
       - name: Validate reqstool spec completeness
@@ -76,11 +76,11 @@ jobs:
         # replacement for) the `reqstool status --fail-if-incomplete` gate below, which
         # is the actual required check on the pypi leg
         if: matrix.reqstool-source == 'main'
-        uses: reqstool/.github/.github/actions/validate-reqstool@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+        uses: reqstool/.github/.github/actions/validate-reqstool@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
       - name: Run reqstool status
         # Required gate on both matrix legs -- fails the build unless every
         # requirement is implemented and verified.
-        uses: reqstool/.github/.github/actions/reqstool-status@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+        uses: reqstool/.github/.github/actions/reqstool-status@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
         with:
           fail-if-incomplete: "true"
       # Upload artifacts for later use
@@ -92,4 +92,4 @@ jobs:
           path: dist/
 
   validate-openspec:
-    uses: reqstool/.github/.github/workflows/common-validate-openspec.yml@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+    uses: reqstool/.github/.github/workflows/common-validate-openspec.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0

--- a/.github/workflows/check-semantic-pr.yml
+++ b/.github/workflows/check-semantic-pr.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   check:
-    uses: reqstool/.github/.github/workflows/common-check-semantic-pr.yml@main
+    uses: reqstool/.github/.github/workflows/common-check-semantic-pr.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   prepare:
-    uses: reqstool/.github/.github/workflows/common-release-prepare.yml@main
+    uses: reqstool/.github/.github/workflows/common-release-prepare.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
     permissions:
       contents: read
     with:
@@ -67,7 +67,7 @@ jobs:
   tag:
     needs: [prepare, checks]
     if: ${{ !inputs.dry-run }}
-    uses: reqstool/.github/.github/workflows/common-release-tag.yml@main
+    uses: reqstool/.github/.github/workflows/common-release-tag.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
     permissions:
       contents: write
     with:
@@ -88,7 +88,7 @@ jobs:
 
   assets:
     needs: [prepare, build-tagged]
-    uses: reqstool/.github/.github/workflows/common-release-assets.yml@main
+    uses: reqstool/.github/.github/workflows/common-release-assets.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
     permissions:
       contents: write
     with:
@@ -109,7 +109,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: reqstool/.github/.github/actions/download-dists@ef815eae0bca7160cdc714126cac73f76d638b39 # main 2026-08-23
+      - uses: reqstool/.github/.github/actions/download-dists@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
         with:
           artifact: dist-tagged
       # Inline, not inside download-dists: nesting this Docker action in a
@@ -131,7 +131,7 @@ jobs:
   promote:
     needs: [prepare, assets, publish-to-pypi]
     if: ${{ !inputs.dry-run && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-    uses: reqstool/.github/.github/workflows/common-release-promote.yml@main
+    uses: reqstool/.github/.github/workflows/common-release-promote.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
     permissions:
       contents: write
     with:


### PR DESCRIPTION
## Description

Implements [reqstool/.github#25](https://github.com/reqstool/.github/issues/25) for this repo.

Every `reqstool/.github` reference here now points at a commit SHA carrying a `# 1.0.0`
comment, replacing the mix of `@main` and `@<sha> # main <date>` that had accumulated.

`reqstool/.github` was tagged [1.0.0](https://github.com/reqstool/.github/releases/tag/1.0.0)
— its first ever tag — at the state verified end to end by this week's releases across all
nine publishing repos.

**Why this shape**, per the discussion on #25:

- `@main` is mutable, so CodeQL's `actions/unpinned-tag` flags it, and a change to
  `reqstool/.github` reaches this repo instantly with no review. We hit exactly that twice
  this week while fixing the PyPI publish path.
- `@1.0.0` alone would still be a mutable tag, so it would keep tripping the same rule.
- `@<sha> # 1.0.0` satisfies the pinning audits, and Renovate tracks the digest and rewrites
  the version comment alongside it — so the pin does not silently rot. That is the same
  treatment third-party actions already get in this org.

A companion PR narrows the `!/^reqstool\//` exclusion in `renovate.json5`, which is what
lets Renovate maintain these going forward. **That one merges after this**, so Renovate does
not try to pin `@main` refs mid-sweep.

## Checklist

- [x] I have reviewed and followed the contributing guidelines.
- [x] I have run a local build and made sure all tests pass.
- [x] I have signed off the DCO (`git commit -s`).
- [x] I have read the Code of Conduct and agree to abide by it.

## Test plan

Mechanical, generated by script and YAML-validated across every touched file. The refs all
resolve to the same tree they did before — `1.0.0` points at `ef815ea`, which is what `@main`
already resolved to when this was written, so no behaviour changes. CI on this PR exercises
the pinned refs directly.
